### PR TITLE
EDUCATOR-2934 Add if statement to check if a duration exists for hls encoding

### DIFF
--- a/chunkey/util_functions.py
+++ b/chunkey/util_functions.py
@@ -72,14 +72,16 @@ def probe_video(VideoFileObject):
         if "Duration: " in line:
             # Duration
             vid_duration = line.split('Duration: ')[1].split(',')[0].strip()
-            VideoFileObject.duration = seconds_from_string(
-                duration=vid_duration
-            )
-            # Bitrate
-            try:
-                VideoFileObject.bitrate = float(line.split('bitrate: ')[1].strip().split()[0])
-            except ValueError:
-                pass
+
+            if vid_duration != 'N/A':
+                VideoFileObject.duration = seconds_from_string(
+                    duration=vid_duration
+                )
+                # Bitrate
+                try:
+                    VideoFileObject.bitrate = float(line.split('bitrate: ')[1].strip().split()[0])
+                except ValueError:
+                    pass
 
         elif "Stream #" in line and 'Video: ' in line:
             codec_array = line.strip().split(',')


### PR DESCRIPTION
## [EDUCATOR-2934](https://openedx.atlassian.net/browse/EDUCATOR-2934)

There is more context on the ticket, but basically we were getting this error

`  File "/usr/local/lib/python2.7/site-packages/Chunkey-1.2.3-py2.7.egg/chunkey/util_functions.py", line 14, in seconds_from_string
    hours = float(duration.split(':')[0])
ValueError: could not convert string to float: N/A`

when attempting to encode a video into hls. For some reason, a .tf file was generated with a start time after the video ended, with a duration of "N/A". This checks for those types of files, who will then get removed from the directory in the parent function.