### PR TITLE
PROD-392: Run python modernize on the repo

### DIFF
--- a/chunkey/__init__.py
+++ b/chunkey/__init__.py
@@ -34,13 +34,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+from __future__ import absolute_import
 import os
 import sys
 import nose
 import json
 
-from encode_pipeline import VideoPipeline
-import util_functions
+from .encode_pipeline import VideoPipeline
+from . import util_functions
 
 
 class Chunkey(object):

--- a/chunkey/encode_pipeline.py
+++ b/chunkey/encode_pipeline.py
@@ -7,6 +7,8 @@ Generate master manifest, upload (easy, via boto) to output bucket
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -17,7 +19,8 @@ from boto.s3.key import Key
 import shutil
 import requests
 
-import util_functions
+from . import util_functions
+import six
 
 try:
     boto.config.add_section('Boto')
@@ -90,7 +93,7 @@ class VideoPipeline(object):
         Function to test and DL from url
         """
         d = requests.head(self.mezz_file, timeout=20)
-        print d.status_code
+        print(d.status_code)
         if d.status_code > 299:
             return False
 
@@ -196,7 +199,7 @@ class VideoPipeline(object):
 
         '''
         encode_profiles = self.settings.TRANSCODE_PROFILES
-        for profile_name, profile in encode_profiles.iteritems():
+        for profile_name, profile in six.iteritems(encode_profiles):
             ffcommand = ['ffmpeg -y -i']
             ffcommand.append(self.mezz_file)
             """
@@ -304,7 +307,7 @@ class VideoPipeline(object):
 
         '''
         encode_profiles = self.settings.TRANSCODE_PROFILES
-        for profile_name, profile in encode_profiles.iteritems():
+        for profile_name, profile in six.iteritems(encode_profiles):
             T1 = TransportStream()
             """
             TS manifest

--- a/chunkey/tests/test_build.py
+++ b/chunkey/tests/test_build.py
@@ -4,6 +4,7 @@ main build test
 Note: until we include ffmpeg in the build, there's only so much we can do
 
 """
+from __future__ import absolute_import
 import os
 import sys
 import unittest

--- a/chunkey/tests/test_hls_chunker.py
+++ b/chunkey/tests/test_hls_chunker.py
@@ -1,4 +1,5 @@
 
+from __future__ import absolute_import
 import os
 import sys
 import unittest

--- a/chunkey/util_functions.py
+++ b/chunkey/util_functions.py
@@ -3,6 +3,8 @@
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import subprocess
 
@@ -52,7 +54,7 @@ def status_bar(process):
     sys.stdout.write('\r')
     sys.stdout.write("%s : [%-20s] %d%%" % ('Transcode', '=' * 20, 100))
     sys.stdout.flush()
-    print ''
+    print('')
 
 
 def probe_video(VideoFileObject):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 
+from __future__ import absolute_import
 from setuptools import setup
 
 


### PR DESCRIPTION
Run python modernize on the repo.

Specifically: `python-modernize  -w .`
This work is for [PROD-392](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=537&modal=detail&selectedIssue=PROD-392). This is part of the effort to convert code base from python 2.7 to python 3.
