### PR TITLE
Fix bandwidth calculation

### DIFF
--- a/chunkey/encode_pipeline.py
+++ b/chunkey/encode_pipeline.py
@@ -260,14 +260,24 @@ class VideoPipeline(object):
 
     def _determine_bandwidth(self, profile_name):
         """
-        TODO: Determine more accurate transmission overhead
+        Calculates upper bound of the overall bitrate for given stream profile
+
+        Enumerate all fragment files to find largest file in terms of size for give stream profile.
+        Get size of large file in bits, divide it by chunk/fragment duration to get bandwidth.
+
+        Arguments:
+            profile_name (str): profile index
+
+        Returns:
+            int: maximum bandwidth for given stream profile
         """
         max_bandwidth = 0.0
 
         for input_file in os.listdir(self.video_root):
             if fnmatch.fnmatch(input_file, '*.ts') and \
                     fnmatch.fnmatch(input_file, '_'.join((self.video_id, profile_name, '*'))):
-                bandwidth = float(os.stat(os.path.join(self.video_root, input_file)).st_size) / 9
+                file_size_bits = float(os.stat(os.path.join(self.video_root, input_file)).st_size) * 8
+                bandwidth = file_size_bits / self.settings.HLS_TIME
                 if bandwidth > max_bandwidth:
                     max_bandwidth = bandwidth
 


### PR DESCRIPTION
There is a bug in the HLS encoding pipeline which sets invalid upper bound of the overall bitrate(BANDWIDTH) in playlists. As a result of this HLS player is unable to distinguish between different streams of HLS video and loses the main benefit of HLS which is adaptive stream. A user who is on a regular 2G connection is forced to download a high resolution stream which should be downloaded in case of DSL or high bandwidth connection. This PR fixes the issue.